### PR TITLE
Support code blocks fenced with "cpp"

### DIFF
--- a/clang_format_docs.py
+++ b/clang_format_docs.py
@@ -14,7 +14,7 @@ from typing import Sequence
 
 
 MD_RE = re.compile(
-    r'(?P<before>^(?P<indent> *)```\s*[cC]\+\+\n)'
+    r'(?P<before>^(?P<indent> *)```\s*([cC]\+\+|cpp)\n)'
     r'(?P<code>.*?)'
     r'(?P<after>^(?P=indent)```\s*$)',
     re.DOTALL | re.MULTILINE,

--- a/tests/test_clang_format_docs.py
+++ b/tests/test_clang_format_docs.py
@@ -64,6 +64,22 @@ def test_format_src_simple():
     )
 
 
+def test_cpp_lexer():
+    before = (
+        '```cpp\n'
+        'void f (1,2,3){}\n'
+        '```\n'
+    )
+    after, _ = clang_format_docs.format_str(before)
+    assert after == (
+        '```cpp\n'
+        'void f(1, 2, 3)\n'
+        '{\n'
+        '}\n'
+        '```\n'
+    )
+
+
 def test_clang_format_not_found_raises_RuntimeError():
     with mock.patch.object(clang_format_docs.shutil, 'which') as m:
         m.return_value = None


### PR DESCRIPTION
The pygments lexer, commonly used by Markdown parsers, supports "cpp" in addition to "c++" as format specifier for C++ code (see https://pygments.org/docs/lexers/#pygments.lexers.c_cpp.CppLexer). Add support fenced blocks with "cpp", in the same way "c++" is supported.