### PR TITLE
Use existing types over files regex

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,4 @@
     entry: clang-format-docs
     language: python
     language_version: python3
-    files: '\.(md|markdown)$'
+    types: [markdown]


### PR DESCRIPTION
In https://github.com/pre-commit/identify/blob/62ca9e506b73aa9deb71162a2881c235f25f27cf/identify/extensions.py#L150-L151, pre-commit already defines what should be considered as markdown. Let's just reuse this.